### PR TITLE
I've converted strings storing type names into IClrTypeName

### DIFF
--- a/Source/Machine.Specifications.ReSharperRunner.6.0/Factories/BehaviorFactory.cs
+++ b/Source/Machine.Specifications.ReSharperRunner.6.0/Factories/BehaviorFactory.cs
@@ -4,6 +4,7 @@ using JetBrains.Metadata.Reader.API;
 using JetBrains.ProjectModel;
 using JetBrains.ReSharper.Psi;
 using JetBrains.ReSharper.Psi.Caches;
+using JetBrains.ReSharper.Psi.Impl.Reflection2;
 using JetBrains.ReSharper.UnitTestFramework;
 #if RESHARPER_61
 using JetBrains.ReSharper.UnitTestFramework.Elements;
@@ -20,6 +21,7 @@ namespace Machine.Specifications.ReSharperRunner.Factories
     readonly ElementCache _cache;
     readonly IProject _project;
 #if RESHARPER_61
+    readonly ReflectionTypeNameCache _reflectionTypeNameCache = new ReflectionTypeNameCache();
     readonly IUnitTestElementManager _manager;
     readonly PsiModuleManager _psiModuleManager;
     readonly CacheManager _cacheManager;
@@ -65,7 +67,7 @@ namespace Machine.Specifications.ReSharperRunner.Factories
                                  _project,
                                  _projectEnvoy,
                                  context,
-                                 clazz.GetClrName().FullName,
+                                 clazz.GetClrName(),
                                  field.ShortName,
                                  field.IsIgnored(),
                                  fullyQualifiedTypeName);
@@ -93,7 +95,12 @@ namespace Machine.Specifications.ReSharperRunner.Factories
                                                 _project,
                                                 _projectEnvoy,
                                                 context,
-                                                behavior.DeclaringType.FullyQualifiedName,
+#if RESHARPER_61
+                                                _reflectionTypeNameCache.GetClrName(behavior.DeclaringType),
+#else
+                                                new ClrTypeName(behavior.DeclaringType.FullyQualifiedName), // may work incorrect in ReSharper 6.0
+#endif
+
                                                 behavior.Name,
                                                 behavior.IsIgnored() || typeContainingBehaviorSpecifications.IsIgnored(),
                                                 fullyQualifiedTypeName);
@@ -110,7 +117,7 @@ namespace Machine.Specifications.ReSharperRunner.Factories
                                                       IProject project,
                                                       ProjectModelElementEnvoy projectEnvoy,
                                                       ContextElement context,
-                                                      string declaringTypeName,
+                                                      IClrTypeName declaringTypeName,
                                                       string fieldName,
                                                       bool isIgnored,
                                                       string fullyQualifiedTypeName)

--- a/Source/Machine.Specifications.ReSharperRunner.6.0/Factories/ContextFactory.cs
+++ b/Source/Machine.Specifications.ReSharperRunner.6.0/Factories/ContextFactory.cs
@@ -6,6 +6,7 @@ using JetBrains.Metadata.Reader.API;
 using JetBrains.ProjectModel;
 using JetBrains.ReSharper.Psi;
 using JetBrains.ReSharper.Psi.Caches;
+using JetBrains.ReSharper.Psi.Impl.Reflection2;
 using JetBrains.ReSharper.UnitTestFramework;
 #if RESHARPER_61
 using JetBrains.ReSharper.UnitTestFramework.Elements;
@@ -24,6 +25,7 @@ namespace Machine.Specifications.ReSharperRunner.Factories
     readonly ElementCache _cache;
     readonly IProject _project;
 #if RESHARPER_61
+    readonly ReflectionTypeNameCache _reflectionTypeNameCache = new ReflectionTypeNameCache();
     readonly IUnitTestElementManager _manager;
     readonly PsiModuleManager _psiModuleManager;
     readonly CacheManager _cacheManager;
@@ -56,7 +58,7 @@ namespace Machine.Specifications.ReSharperRunner.Factories
 #endif
                                               _project,
                                               _projectEnvoy,
-                                              type.GetClrName().FullName,
+                                              type.GetClrName().GetPersistent(),
                                               _assemblyPath,
                                               type.GetSubjectString(),
                                               type.GetTags(),
@@ -81,7 +83,11 @@ namespace Machine.Specifications.ReSharperRunner.Factories
 #endif
                                        _project,
                                        _projectEnvoy,
-                                       type.FullyQualifiedName,
+#if RESHARPER_61
+                                       _reflectionTypeNameCache.GetClrName(type),
+#else
+                                       new ClrTypeName(type.FullyQualifiedName), // may work incorrect in ReSharper 6.0
+#endif
                                        _assemblyPath,
                                        type.GetSubjectString(),
                                        type.GetTags(),
@@ -96,13 +102,13 @@ namespace Machine.Specifications.ReSharperRunner.Factories
 #endif
                                                     IProject project,
                                                     ProjectModelElementEnvoy projectEnvoy,
-                                                    string typeName,
+                                                    IClrTypeName typeName,
                                                     string assemblyLocation,
                                                     string subject,
                                                     ICollection<string> tags,
                                                     bool isIgnored)
     {
-      var id = ContextElement.CreateId(subject, typeName, tags);
+      var id = ContextElement.CreateId(subject, typeName.FullName, tags);
 #if RESHARPER_61
       var contextElement = manager.GetElementById(project, id) as ContextElement;
 #else

--- a/Source/Machine.Specifications.ReSharperRunner.6.0/Factories/ContextSpecificationFactory.cs
+++ b/Source/Machine.Specifications.ReSharperRunner.6.0/Factories/ContextSpecificationFactory.cs
@@ -4,6 +4,7 @@ using JetBrains.Metadata.Reader.API;
 using JetBrains.ProjectModel;
 using JetBrains.ReSharper.Psi;
 using JetBrains.ReSharper.Psi.Caches;
+using JetBrains.ReSharper.Psi.Impl.Reflection2;
 using JetBrains.ReSharper.UnitTestFramework;
 #if RESHARPER_61
 using JetBrains.ReSharper.UnitTestFramework.Elements;
@@ -20,6 +21,7 @@ namespace Machine.Specifications.ReSharperRunner.Factories
     readonly ElementCache _cache;
     readonly IProject _project;
 #if RESHARPER_61
+    readonly ReflectionTypeNameCache _reflectionTypeNameCache = new ReflectionTypeNameCache();
     readonly IUnitTestElementManager _manager;
     readonly PsiModuleManager _psiModuleManager;
     readonly CacheManager _cacheManager;
@@ -63,7 +65,7 @@ namespace Machine.Specifications.ReSharperRunner.Factories
                                              _project,
                                              context,
                                              _projectEnvoy,
-                                             clazz.GetClrName().FullName,
+                                             clazz.GetClrName().GetPersistent(),
                                              field.ShortName,
                                              clazz.GetTags(),
                                              field.IsIgnored());
@@ -78,7 +80,11 @@ namespace Machine.Specifications.ReSharperRunner.Factories
                                              _project,
                                              context,
                                              _projectEnvoy,
-                                             specification.DeclaringType.FullyQualifiedName,
+#if RESHARPER_61
+                                             _reflectionTypeNameCache.GetClrName(specification.DeclaringType),
+#else
+                                             new ClrTypeName(specification.DeclaringType.FullyQualifiedName), // may work incorrect in ReSharper 6.0
+#endif
                                              specification.Name,
                                              specification.DeclaringType.GetTags(),
                                              specification.IsIgnored());
@@ -93,7 +99,7 @@ namespace Machine.Specifications.ReSharperRunner.Factories
                                                                               IProject project,
                                                                               ContextElement context,
                                                                               ProjectModelElementEnvoy projectEnvoy,
-                                                                              string declaringTypeName,
+                                                                              IClrTypeName declaringTypeName,
                                                                               string fieldName,
                                                                               ICollection<string> tags,
                                                                               bool isIgnored)

--- a/Source/Machine.Specifications.ReSharperRunner.6.0/Factories/UnitTestTaskFactory.cs
+++ b/Source/Machine.Specifications.ReSharperRunner.6.0/Factories/UnitTestTaskFactory.cs
@@ -27,7 +27,7 @@ namespace Machine.Specifications.ReSharperRunner.Factories
       return new UnitTestTask(context,
                               new ContextTask(_providerId,
                                               context.AssemblyLocation,
-                                              context.GetTypeClrName(),
+                                              context.GetTypeClrName().FullName,
                                               false));
     }
 
@@ -38,7 +38,7 @@ namespace Machine.Specifications.ReSharperRunner.Factories
       return new UnitTestTask(contextSpecification,
                               new ContextSpecificationTask(_providerId,
                                                            context.AssemblyLocation,
-                                                           context.GetTypeClrName(),
+                                                           context.GetTypeClrName().FullName,
                                                            contextSpecification.FieldName,
                                                            false));
     }
@@ -48,7 +48,7 @@ namespace Machine.Specifications.ReSharperRunner.Factories
       return new UnitTestTask(behavior,
                               new BehaviorTask(_providerId,
                                                context.AssemblyLocation,
-                                               context.GetTypeClrName(),
+                                               context.GetTypeClrName().FullName,
                                                behavior.FullyQualifiedTypeName,
                                                behavior.FieldName,
                                                false));
@@ -61,10 +61,10 @@ namespace Machine.Specifications.ReSharperRunner.Factories
       return new UnitTestTask(behaviorSpecification,
                               new BehaviorSpecificationTask(_providerId,
                                                             context.AssemblyLocation,
-                                                            context.GetTypeClrName(),
+                                                            context.GetTypeClrName().FullName,
                                                             behaviorSpecification.Behavior.FieldName,
                                                             behaviorSpecification.FieldName,
-                                                            behaviorSpecification.GetTypeClrName(),
+                                                            behaviorSpecification.GetTypeClrName().FullName,
                                                             false));
     }
   }

--- a/Source/Machine.Specifications.ReSharperRunner.6.0/Presentation/BehaviorElement.cs
+++ b/Source/Machine.Specifications.ReSharperRunner.6.0/Presentation/BehaviorElement.cs
@@ -23,7 +23,7 @@ namespace Machine.Specifications.ReSharperRunner.Presentation
                            ContextElement context,
       // ReSharper restore SuggestBaseTypeForParameter
                            ProjectModelElementEnvoy projectEnvoy,
-                           string declaringTypeName,
+                           IClrTypeName declaringTypeName,
                            string fieldName,
                            bool isIgnored,
                            string fullyQualifiedTypeName)
@@ -92,7 +92,7 @@ namespace Machine.Specifications.ReSharperRunner.Presentation
                                                            project,
                                                            ProjectModelElementEnvoy.Create(project),
                                                            context,
-                                                           typeName,
+                                                           new ClrTypeName(typeName),
                                                            methodName,
                                                            isIgnored,
                                                            fullyQualifiedTypeName);

--- a/Source/Machine.Specifications.ReSharperRunner.6.0/Presentation/BehaviorSpecificationElement.cs
+++ b/Source/Machine.Specifications.ReSharperRunner.6.0/Presentation/BehaviorSpecificationElement.cs
@@ -25,7 +25,7 @@ namespace Machine.Specifications.ReSharperRunner.Presentation
                                         BehaviorElement behavior,
       // ReSharper restore SuggestBaseTypeForParameter
                                         ProjectModelElementEnvoy projectEnvoy,
-                                        string declaringTypeName,
+                                        IClrTypeName declaringTypeName,
                                         string fieldName,
                                         bool isIgnored)
       : base(provider, psiModuleManager, cacheManager, behavior, projectEnvoy, declaringTypeName, fieldName, isIgnored || behavior.Explicit)
@@ -75,7 +75,7 @@ namespace Machine.Specifications.ReSharperRunner.Presentation
 #if RESHARPER_61
         manager, psiModuleManager, cacheManager,
 #endif
-        project, behavior, ProjectModelElementEnvoy.Create(project), typeName, methodName, isIgnored);
+        project, behavior, ProjectModelElementEnvoy.Create(project), new ClrTypeName(typeName), methodName, isIgnored);
     }
 
     public override string Id

--- a/Source/Machine.Specifications.ReSharperRunner.6.0/Presentation/ContextElement.cs
+++ b/Source/Machine.Specifications.ReSharperRunner.6.0/Presentation/ContextElement.cs
@@ -28,14 +28,14 @@ namespace Machine.Specifications.ReSharperRunner.Presentation
                           PsiModuleManager psiModuleManager,
                           CacheManager cacheManager,
                           ProjectModelElementEnvoy projectEnvoy,
-                          string typeName,
+                          IClrTypeName typeName,
                           string assemblyLocation,
                           string subject,
                           IEnumerable<string> tags,
                           bool isIgnored)
       : base(provider, psiModuleManager, cacheManager, null, projectEnvoy, typeName, isIgnored)
     {
-      _id = CreateId(subject, TypeName, tags);
+      _id = CreateId(subject, TypeName.FullName, tags);
       _assemblyLocation = assemblyLocation;
       _subject = subject;
 
@@ -57,7 +57,7 @@ namespace Machine.Specifications.ReSharperRunner.Presentation
 
     public override string GetPresentation()
     {
-      return GetSubject() + new ClrTypeName(GetTypeClrName()).ShortName.ToFormat();
+      return GetSubject() + GetTypeClrName().ShortName.ToFormat();
     }
 
     string GetSubject()
@@ -88,7 +88,7 @@ namespace Machine.Specifications.ReSharperRunner.Presentation
     public void WriteToXml(XmlElement parent)
     {
       parent.SetAttribute("projectId", GetProject().GetPersistentID());
-      parent.SetAttribute("typeName", TypeName);
+      parent.SetAttribute("typeName", TypeName.FullName);
       parent.SetAttribute("assemblyLocation", AssemblyLocation);
       parent.SetAttribute("isIgnored", Explicit.ToString());
       parent.SetAttribute("subject", _subject);
@@ -118,7 +118,7 @@ namespace Machine.Specifications.ReSharperRunner.Presentation
 #endif
                                                       project,
                                                       ProjectModelElementEnvoy.Create(project),
-                                                      typeName,
+                                                      new ClrTypeName(typeName),
                                                       assemblyLocation,
                                                       subject,
                                                       EmptyArray<string>.Instance,

--- a/Source/Machine.Specifications.ReSharperRunner.6.0/Presentation/ContextSpecificationElement.cs
+++ b/Source/Machine.Specifications.ReSharperRunner.6.0/Presentation/ContextSpecificationElement.cs
@@ -27,7 +27,7 @@ namespace Machine.Specifications.ReSharperRunner.Presentation
                                        ContextElement context,
       // ReSharper restore SuggestBaseTypeForParameter
                                        ProjectModelElementEnvoy project,
-                                       string declaringTypeName,
+                                       IClrTypeName declaringTypeName,
                                        string fieldName,
                                        IEnumerable<string> tags,
                                        bool isIgnored)
@@ -83,7 +83,7 @@ namespace Machine.Specifications.ReSharperRunner.Presentation
 #if RESHARPER_61
                 manager, psiModuleManager, cacheManager,
 #endif
-                project, context, ProjectModelElementEnvoy.Create(project), typeName, methodName, EmptyArray<string>.Instance, isIgnored);
+                project, context, ProjectModelElementEnvoy.Create(project), new ClrTypeName(typeName), methodName, EmptyArray<string>.Instance, isIgnored);
     }
 
     public override string Id

--- a/Source/Machine.Specifications.ReSharperRunner.6.0/Presentation/Element.cs
+++ b/Source/Machine.Specifications.ReSharperRunner.6.0/Presentation/Element.cs
@@ -16,7 +16,7 @@ namespace Machine.Specifications.ReSharperRunner.Presentation
 {
   public abstract class Element : IUnitTestElement
   {
-    readonly string _declaringTypeName;
+    readonly IClrTypeName _declaringTypeName;
     readonly ProjectModelElementEnvoy _projectEnvoy;
     readonly MSpecUnitTestProvider _provider;
     readonly UnitTestTaskFactory _taskFactory;
@@ -29,7 +29,7 @@ namespace Machine.Specifications.ReSharperRunner.Presentation
                       CacheManager cacheManager,
                       Element parent,
                       ProjectModelElementEnvoy projectEnvoy,
-                      string declaringTypeName,
+                      IClrTypeName declaringTypeName,
                       bool isIgnored)
     {
       if (projectEnvoy == null && !Shell.Instance.IsTestShell)
@@ -65,7 +65,7 @@ namespace Machine.Specifications.ReSharperRunner.Presentation
       _taskFactory = new UnitTestTaskFactory(_provider.ID);
     }
 
-    public string TypeName { get; protected set; }
+    public IClrTypeName TypeName { get; protected set; }
     public abstract string Kind { get; }
     public abstract IEnumerable<UnitTestElementCategory> Categories { get; }
     public string ExplicitReason { get; private set; }
@@ -119,7 +119,7 @@ namespace Machine.Specifications.ReSharperRunner.Presentation
 
     public UnitTestNamespace GetNamespace()
     {
-      return new UnitTestNamespace(new ClrTypeName(_declaringTypeName).GetNamespaceName());
+      return new UnitTestNamespace(_declaringTypeName.GetNamespaceName());
     }
 
     public UnitTestElementDisposition GetDisposition()
@@ -277,7 +277,7 @@ namespace Machine.Specifications.ReSharperRunner.Presentation
       return declarationsCache.GetTypeElementByCLRName(_declaringTypeName);
     }
 
-    public string GetTypeClrName()
+    public IClrTypeName GetTypeClrName()
     {
       return _declaringTypeName;
     }

--- a/Source/Machine.Specifications.ReSharperRunner.6.0/Presentation/FieldElement.cs
+++ b/Source/Machine.Specifications.ReSharperRunner.6.0/Presentation/FieldElement.cs
@@ -21,7 +21,7 @@ namespace Machine.Specifications.ReSharperRunner.Presentation
                            CacheManager cacheManager,
                            Element parent,
                            ProjectModelElementEnvoy projectEnvoy,
-                           string declaringTypeName,
+                           IClrTypeName declaringTypeName,
                            string fieldName,
                            bool isIgnored)
       : base(provider, psiModuleManager, cacheManager, parent, projectEnvoy, declaringTypeName, isIgnored || parent.Explicit)
@@ -69,7 +69,7 @@ namespace Machine.Specifications.ReSharperRunner.Presentation
     public virtual void WriteToXml(XmlElement parent)
     {
       parent.SetAttribute("projectId", GetProject().GetPersistentID());
-      parent.SetAttribute("typeName", TypeName);
+      parent.SetAttribute("typeName", TypeName.FullName);
       parent.SetAttribute("methodName", FieldName);
       parent.SetAttribute("isIgnored", Explicit.ToString());
     }


### PR DESCRIPTION
MSpec provider in ReSharper works well, known bugs with navigation and invalid elements now fixed.
I'm not sure about runner though: it failed to work on my machine and I don't know why, whether it's some configuration issue or changed type name presentation.
